### PR TITLE
chore: avoid warnings for tslib peerDependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "peerDependencies": {
     "redux": ">=4 <5",
     "rxjs": ">=6.0.0-beta.0 <7",
-    "tslib": "^1.9.0"
+    "tslib": "^1.9.0 || ^2.0.3"
   },
   "devDependencies": {
     "@types/chai": "^3.5.2",


### PR DESCRIPTION
<!-- If this is your first PR for redux-observable, please mark these boxes to confirm (otherwise you can exclude them)-->

- [ ] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [ ] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.

I'm currently hitting errors when using npm v7 due to `tslib` peer-dependency mismatches. Would be awesome to silence these by allowing ``tslib` v2+